### PR TITLE
symfony/psr-http-message-bridge versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "homepage": "http://github.com/loophp/psr-http-message-bridge-bundle",
     "require": {
-        "php": ">= 8.1",
-        "symfony/psr-http-message-bridge": "^6.4"
+        "php": ">= 8.2",
+        "symfony/psr-http-message-bridge": "^7.0"
     },
     "require-dev": {
         "drupol/php-conventions": "^5",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "homepage": "http://github.com/loophp/psr-http-message-bridge-bundle",
     "require": {
         "php": ">= 8.2",
-        "symfony/psr-http-message-bridge": "^7.0"
+        "symfony/psr-http-message-bridge": "^7.1"
     },
     "require-dev": {
         "drupol/php-conventions": "^5",

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "homepage": "http://github.com/loophp/psr-http-message-bridge-bundle",
     "require": {
-        "php": ">= 7.3",
-        "symfony/psr-http-message-bridge": "^1 || ^2"
+        "php": ">= 8.1",
+        "symfony/psr-http-message-bridge": "^6.4"
     },
     "require-dev": {
         "drupol/php-conventions": "^5",


### PR DESCRIPTION
Hello,

This PR is related to #82 .

Here's 4 commits upgrading symfony/psr-http-message-bridge versions.

Unfortunately we cannot add tags to a PR, you'll have to do this.

I hope this is enough.

Should we do the same to `loophp/unaltered-psr-http-message-bridge-bundle` ?

