### PR TITLE
Support Symfony 8

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: [ubuntu-latest]
-                php-versions: ['7.4']
+                php-versions: ['8.4']
 
         steps:
             - name: Set git to use LF

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-                php-versions: ['7.4']
+                php-versions: ['8.4']
 
         steps:
             - name: Set git to use LF

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2021-2024 Pol Dellaiera
+Copyright (c) 2021-2026 Pol Dellaiera
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-pcov": "*",
         "drupol/php-conventions": "^6",
         "friends-of-phpspec/phpspec-code-coverage": "^7",
-        "phpspec/phpspec": "^7",
+        "phpspec/phpspec": "^8",
         "symfony/framework-bundle": "^6.4 || ^7 || ^8",
         "symfony/http-kernel": "^6.4 || ^7 || ^8"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     ],
     "homepage": "http://github.com/loophp/psr-http-message-bridge-bundle",
     "require": {
-        "php": ">= 8.1",
-        "symfony/psr-http-message-bridge": "^6.4 || ^7"
+        "php": ">= 8.4",
+        "symfony/psr-http-message-bridge": "^6.4 || ^7 || ^8"
     },
     "require-dev": {
         "ext-pcov": "*",
         "drupol/php-conventions": "^6",
-        "friends-of-phpspec/phpspec-code-coverage": "^6",
+        "friends-of-phpspec/phpspec-code-coverage": "^7",
         "phpspec/phpspec": "^7",
         "symfony/framework-bundle": "^6.4 || ^7 || ^8",
         "symfony/http-kernel": "^6.4 || ^7 || ^8"


### PR DESCRIPTION
## Update PHP requirement to 8.4

This PR
* [x] Bumps PHP requirement from `>= 8.1` to `>= 8.4` in `composer.json` and CI workflows
* [x] Adds Symfony `^8` support to `symfony/psr-http-message-bridge` while keeping `^6.4 || ^7` compatibility
* [x] Updates `friends-of-phpspec/phpspec-code-coverage` from `^6` to `^7`

Follows #99.