### PR TITLE
Update CHANGELOG.md for next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0](https://github.com/loophp/psr-http-message-bridge-bundle/releases/tag/1.3.0)
+
+### Merged
+
+- Support Symfony 8: [#100](https://github.com/loophp/psr-http-message-bridge-bundle/pull/100)
+
+
 ## [1.2.0](https://github.com/loophp/psr-http-message-bridge-bundle/compare/1.1.0...1.2.0)
 
 ### Commits


### PR DESCRIPTION
This PR aims to update the CHANGELOG.md for the upcoming release.

In a previous PR (#100), I forgot to include the changelog update.

* [x] Updates CHANGELOG.md for the next release
* [ ] Requests a new release tag after merge


Would it be possible to tag a new release once this is merged ?